### PR TITLE
translate missing strings

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -3,23 +3,23 @@
 
     <string name="app_name">Prevent Running</string>
 
-    <string name="soak_version">Dies ist keine Releaseversion und könnte dein Gerät unnutzbar machen. Falls du nichts testen willst, deinstalliere diese Version bitte und wechsle zu einer Releaseversion.</string>
+    <string name="soak_version">Dies ist keine Releaseversion und könnte Dein Gerät unnutzbar machen. Falls Du nichts testen willst, deinstalliere diese Version bitte und wechsle zu einer Releaseversion.</string>
 
     <!-- xposed -->
     <string name="xposed_summary">Hindere Apps am Laufen</string>
-    <string name="xposed_disabled">Bitte schalte \"Prevent Running\" im \"Xposed Installer\" ein und starte dein Gerät neu.</string>
+    <string name="xposed_disabled">Bitte aktiviere \"Prevent Running\" im \"Xposed Installer\" und starte Dein Gerät neu.</string>
     <string name="install_internal">Prevent Running sollte im internen Speicher installiert werden.</string>
-    <string name="no_xposed">Bitte installieren Sie \"Xposed Installer\".</string>
+    <string name="no_xposed">Bitte installiere \"Xposed Installer\".</string>
 
     <!-- receiver -->
     <string name="no_prevents">Bitte konfiguriere die Blockier-Liste.</string>
     <string name="updated_prevents">Blockier-Liste auf %1$d aktualisiert</string>
-    <string name="not_supported">ROM wird nicht unterstützt: Bitte melden Sie den Fehler an die Entwickler.</string>
+    <string name="not_supported">ROM wird nicht unterstützt: Bitte melde den Fehler an den Entwickler.</string>
 
     <!-- main activity -->
-    <string name="version_mismatch">Bitte starte dein Gerät neu, um die aktuelle Version zu aktivieren</string>
+    <string name="version_mismatch">Bitte starte Dein Gerät neu, um die aktuelle Version zu aktivieren</string>
     <string name="reboot">Geräte-Neustart</string>
-    <string name="are_you_sure">Bist du sicher?</string>
+    <string name="are_you_sure">Bist Du sicher?</string>
     <string name="applications">Anwendungen</string>
     <string name="prevent_list">Blockier-Liste</string>
     <string name="prevent">Automatisch blockieren</string>
@@ -62,12 +62,12 @@
     <string name="backup_prevent_list">Blockier-Liste auf externen Speicher sichern</string>
     <string name="lock_sync">Synchronisieren sperren</string>
     <string name="lock_sync_settings">Verhindert, dass Apps deaktivierte Synchronisationseinträge wieder einschalten</string>
-    <string name="auto_prevent">Auto verhindern</string>
-    <string name="auto_update_prevent">Auto verhindern neue App</string>
+    <string name="auto_prevent">Automatisch verhindern</string>
+    <string name="auto_update_prevent">Neue Apps automatisch blockieren</string>
     <string name="use_app_standby">App-Ruhezustand</string>
     <string name="use_app_standby_settings">Versetze Apps in Standby, anstatt ein Beenden zu erzwingen</string>
-    <string name="allow_empty_sender">Allow Unknown Sender (English)</string>
-    <string name="allow_empty_sender_in_service">Allow unknown sender to start service, which is useful to open some apps directly through notification or widget, however, it may has side effects (English)</string>
+    <string name="allow_empty_sender">Unbekannte Aufrufe erlauben</string>
+    <string name="allow_empty_sender_in_service">Anderen Apps erlauben, Services zu starten. Dies ist nützlich, um manche Apps direkt durch Benachrichtigungen oder Widgets zu öffnen, es könnte jedoch auch unerwünschte Auswirkungen haben</string>
     <string name="force_stop_signature_apps">Force Stop Signature Apps (English)</string>
     <string name="force_stop_uncheckable_signature_apps">It\'s uncheckable, and cannot be added to prevent list without a \"prevent all\" license (English)</string>
     <string name="force_stop_label">Beenden von Hintergrund-Apps erzwingen</string>
@@ -81,7 +81,7 @@
 
     <!-- request license -->
     <string name="no_license">Bitte spende mindestens 2 USD und kontaktiere dann den Entwickler, um eine Lizenz zu erhalten.</string>
-    <string name="no_valid_license">Diese Lizenz gehört \"%1$s\", du hast keine Berechtigung, sie zu benutzen. Forder bitte eine neue an.</string>
+    <string name="no_valid_license">Diese Lizenz gehört \"%1$s\", Du hast keine Berechtigung, sie zu benutzen. Fordere bitte eine neue an.</string>
     <string name="email_request">E-Mail</string>
     <string name="copy_request">@android:string/copy</string>
 
@@ -92,10 +92,10 @@
     <string name="report_bug">Fehler melden</string>
     <string name="request_license">Lizenz anfordern</string>
     <string name="advanced_settings">Erweiterte Einstellungen</string>
-    <string name="choose_email">Bitte wählen Sie einen E-Mail-Client aus</string>
+    <string name="choose_email">Bitte wähle einen E-Mail-Client aus</string>
 
     <!-- donation -->
-    <string name="donation">Spenden sind gern gesehen, wenn du magst.</string>
+    <string name="donation">Spenden sind gern gesehen, wenn Du magst.</string>
     <string name="select_qr_code">QR-Code aus Album wählen</string>
     <string name="paypal">PayPal</string>
 

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -68,8 +68,8 @@
     <string name="use_app_standby_settings">Versetze Apps in Standby, anstatt ein Beenden zu erzwingen</string>
     <string name="allow_empty_sender">Unbekannte Aufrufe erlauben</string>
     <string name="allow_empty_sender_in_service">Anderen Apps erlauben, Services zu starten. Dies ist nützlich, um manche Apps direkt durch Benachrichtigungen oder Widgets zu öffnen, es könnte jedoch auch unerwünschte Auswirkungen haben</string>
-    <string name="force_stop_signature_apps">Force Stop Signature Apps (English)</string>
-    <string name="force_stop_uncheckable_signature_apps">It\'s uncheckable, and cannot be added to prevent list without a \"prevent all\" license (English)</string>
+    <string name="force_stop_signature_apps">Wichtige Systemanwendungen blockieren</string>
+    <string name="force_stop_uncheckable_signature_apps">Diese sind nicht anklickbar und können nicht ohne eine "Alle Blockieren"-Lizenz zur Blockier-Liste hinzugefügt werden</string>
     <string name="force_stop_label">Beenden von Hintergrund-Apps erzwingen</string>
     <string name="force_stop_summary">%1$s nach Bildschirm aus und Inaktivität der Hintergrund-Apps</string>
     <string name="force_stop_never">Nie (Empfohlen)</string>


### PR DESCRIPTION
What do you mean by "Force Stop Signature Apps"? Is it only GApps or system apps in general? Does that really mean 'force stop' or rather 'prevent' these apps?
In the description of the String above it says 'It[...] cannot be added to prevent list without a "prevent all" license'. Do you refer to the "Prevent Running" license? 